### PR TITLE
Bug fixes

### DIFF
--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -24,7 +24,6 @@ This is a 'py.test' test for the PowerMeter module.
 
 from __future__ import absolute_import, division, print_function
 import os
-import time
 import random
 import logging
 import subprocess
@@ -37,7 +36,12 @@ class CmdLineArgs(object):
     devnode = None
 
 _LOG = logging.getLogger()
-_logging.setup_logger(_LOG, getattr(logging, pytest.config.getoption("--loglevel").upper()))
+try:
+    import sys
+    _LOG_LEVEL = sys.argv[sys.argv.index("--loglevel") + 1].upper()
+    _logging.setup_logger(_LOG, getattr(logging, _LOG_LEVEL))
+except ValueError:
+    pass
 
 class YokotoolPowerMeter():
     """

--- a/yokolibs/PowerMeter.py
+++ b/yokolibs/PowerMeter.py
@@ -97,7 +97,7 @@ class PowerMeter:
         wrapper.initial_indent = " * "
         wrapper. subsequent_indent = "   "
         for pmtype, cls, err in errors:
-            msg = "%s: %s" % (pmtype, cls, err)
+            msg = "%s: %s %s" % (pmtype, cls, err)
             lines += wrapper.wrap(msg)
 
         raise Error("\n".join(lines))


### PR DESCRIPTION
I found these bugs with pylint: unneeded import, broken print formatting and use of 'pytest.config' that is deprecated.