### PR TITLE
Switch to SPDX license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <!--
+Copyright (c) 2013-2018 Intel, Inc.
+SPDX-License-Identifier: GPL-2.0-only
+
 -*- coding: utf-8 -*-
 vim: ts=4 sw=4 tw=100 et ai si
 
-Copyright (c) 2013-2018 Intel, Inc.
-License: GPLv2
 Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
 -->
 - [Introduction](#introduction)

--- a/__main__.py
+++ b/__main__.py
@@ -1,19 +1,12 @@
 #!/usr/bin/python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 import re
 import sys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This is a py.test configuration file that adds the the '--devspec' option support. This option

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This is a 'py.test' test for the PowerMeter module.

--- a/yokolibs/Helpers.py
+++ b/yokolibs/Helpers.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 Misc. helper functions.

--- a/yokolibs/PowerMeter.py
+++ b/yokolibs/PowerMeter.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2016-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2016 Intel, Inc.
-# License: GPLv2
 # Authors: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
 #          Helia Correia <helia.correia@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This module provides API for controlling Yokogawa power meters.

--- a/yokolibs/Transport.py
+++ b/yokolibs/Transport.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 Transport interface class to an instrument. This layer provides basic functions to communicate with

--- a/yokolibs/_config.py
+++ b/yokolibs/_config.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This is an internal module that parses the yokotool configuration file.

--- a/yokolibs/_exceptions.py
+++ b/yokolibs/_exceptions.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2016-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2016 Intel, Inc.
-# License: GPLv2
 # Author: Helia Correia <helia.correia@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """This module defines the exception types used by all of Yoko Tool's modules."""
 

--- a/yokolibs/_logging.py
+++ b/yokolibs/_logging.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 Configure the logger.

--- a/yokolibs/_wt210.py
+++ b/yokolibs/_wt210.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 # Historical note: this module was created by copying the _wt310.py module.
 

--- a/yokolibs/_wt310.py
+++ b/yokolibs/_wt310.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This module implements the Yokogawa WT310 power meter support. It also works for WT330 series, but

--- a/yokolibs/_yokobase.py
+++ b/yokolibs/_yokobase.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 This module contains the common code shared by all the supported power meters so far. The module is

--- a/yokolibs/yokotool.py
+++ b/yokolibs/yokotool.py
@@ -1,19 +1,12 @@
 #!/usr/bin/python
+#
+# Copyright (C) 2013-2020 Intel Corporation
+# SPDX-License-Identifier: GPL-2.0-only
+#
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 tw=100 et ai si
 #
-# Copyright (c) 2013-2018 Intel, Inc.
-# License: GPLv2
 # Author: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License, version 2,
-# as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# General Public License for more details.
 
 """
 A tool for controlling the Yokogawa power meters.


### PR DESCRIPTION
Replace license section with SPDX license identifier.

Signed-off-by: Antti Laakso <antti.laakso@linux.intel.com>